### PR TITLE
Fix MacOS CI build

### DIFF
--- a/cmake/ExternalAnalyzerSDK.cmake
+++ b/cmake/ExternalAnalyzerSDK.cmake
@@ -15,7 +15,7 @@ if(NOT TARGET Saleae::AnalyzerSDK)
     FetchContent_Declare(
         analyzersdk
         GIT_REPOSITORY https://github.com/saleae/AnalyzerSDK.git
-        GIT_TAG        alpha
+        GIT_TAG        master
         GIT_SHALLOW    True
         GIT_PROGRESS   True
     )


### PR DESCRIPTION
The root problem here is that we changed the ExternalAnalyzerSDK.cmake file on the sample analyzer to add support for building both arm64 and x86_64 builds on MacOS, but that change needed to be propagated to anyone using the SampleAnalyzer in order to build for both Mac targets.

The only actual change was which branch of the AnalyzerSDK to track.