### PR TITLE
Fix for malformed WAV output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
         cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
         cmake --build ${{github.workspace}}/build
       env:
-        CC:   gcc-10
-        CXX:  g++-10
+        CC:   gcc-14
+        CXX:  g++-14
     - name: Upload Linux build
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
       - '*'
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    branches: [main]
 
 jobs:
   windows:

--- a/src/TdmAnalyzerResults.cpp
+++ b/src/TdmAnalyzerResults.cpp
@@ -265,10 +265,8 @@ void PCMWaveFileHandler::addSample(U64 sample)
         sample = sample + (1ULL << (7 - mBitShift));
     }
 
-    // writeLittleEndianData(sample << mBitShift, mBytesPerChannel);
     mSampleData[mSampleIndex++] = sample;
     
-    //if(((++mSampleCount) % mNumChannels) == 0){
     if(mSampleIndex >= mNumChannels){ // we have another complete frame
         mTotalFrames++;
         mSampleCount += mNumChannels;
@@ -400,10 +398,8 @@ void PCMExtendedWaveFileHandler::addSample(U64 sample)
         sample = sample + (1ULL << (7 - mBitShift));
     }
 
-    // writeLittleEndianData(sample << mBitShift, mBytesPerChannel);
     mSampleData[mSampleIndex++] = sample;
     
-    //if(((++mSampleCount) % mNumChannels) == 0){
     if(mSampleIndex >= mNumChannels){ // we have another complete frame
         mTotalFrames++;
         mSampleCount += mNumChannels;

--- a/src/TdmAnalyzerResults.h
+++ b/src/TdmAnalyzerResults.h
@@ -118,6 +118,8 @@ class PCMWaveFileHandler
     U32 mTotalFrames;
     std::ofstream & mFile;
     std::streampos mWtPosSaved;
+    U64* mSampleData;
+    U32  mSampleIndex;
 
     constexpr static U64 RIFF_CKSIZE_POS = 4;
     constexpr static U64 DATA_CKSIZE_POS = 40;
@@ -148,6 +150,8 @@ class PCMExtendedWaveFileHandler
     U32 mTotalFrames;
     std::ofstream & mFile;
     std::streampos mWtPosSaved;
+    U64* mSampleData;
+    U32  mSampleIndex;
 
     constexpr static U64 EXT_RIFF_CKSIZE_POS = 4;
     constexpr static U64 EXT_FACT_CKSIZE_POS = 68;


### PR DESCRIPTION
Fixes #7 

I think this works, but only compiled using github actions, and only tested on Windows 10! Extended WAV file not tested, as it appears only to be a compile-time option; it has the same changes, so if it worked before, chances are it still does.